### PR TITLE
Patch for using PyPDFium2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pypdf2~=1.26.0
-pypdfium~=0.0.15
+pypdfium2~=0.1.0
 requests~=2.26.0
 validators~=0.18.2
 Flask~=2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pypdf2~=1.26.0
-pypdfium2~=0.1.0
+pypdfium2~=0.4.0
 requests~=2.26.0
 validators~=0.18.2
 Flask~=2.0.1


### PR DESCRIPTION
Hello,

I'm a former contributor of PyPDFium and now co-author of PyPDFium2. I noticed that this project is using PyPDFium to rasterise PDFs, but it is now deprecated and succeeded by PyPDFium2.
We have applied several modernisations like platform specific wheel builds, automatic pdfium init/deinit calls and a small, pythonic support model API to facilitate rendering PDFs. PyPDFium2 will be updated on a regular basis, while no further releases are planned for PyPDFium.

This patch modifies `extractor.py` to use PyPDFium2 rather than PyPDFium. It does not change the functionality in any way.

https://github.com/pypdfium2-team/pypdfium2
https://pypi.org/project/pypdfium2/