### PR TITLE
Use pypdfium2 support model for extraction of text links

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==2.0.3
 numpy==1.22.1
 PyPDF2==1.26.0
-pypdfium2==0.15.0
+pypdfium2==2.0.0
 requests==2.27.1
 statsmodels==0.13.1
 validators==0.18.2


### PR DESCRIPTION
Simplify the code by using pypdfium2 support model functions rather than accessing the raw API and ctypes directly.