### PR TITLE
Fix CFF version used in citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 1.0
+cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 authors:
 - family-names: "Escamilla"


### PR DESCRIPTION
Hi @elescamilla, as mentioned this pull request fixes a minor issue with the citation file.

- `cff-version` should be `1.2.0` (the latest CFF version). This value is validated against an enum.
- The changes validate with [cffconvert](https://pypi.org/project/cffconvert/) (`cffconvert --validate -i CITATION.cff`), result: 

> Citation metadata are valid according to schema version 1.2.0.

There is also a GitHub Action available for running cffconvert validation when you push to the repository, if you want to continuously make sure that the information in the file is valid: https://github.com/marketplace/actions/cffconvert. I'd be happy to put up another pull request that adds this action.