### PR TITLE
Add LICENSE file with copyright and licensing terms

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright (c) 2021 Emily Escamilla
+
+Python and R source code (`*.py`, `*.Rmd`) in this repository is licensed under the terms of the
+[`MIT License`](https://spdx.org/licenses/MIT).
+
+All other content in this repository is licensed under the terms of the
+[`Creative Commons Attribution 4.0 International`](https://spdx.org/licenses/CC-BY-4.0) license.


### PR DESCRIPTION
This is a simple fix for #4

- Assumes same copyright as master thesis with year of initial commit
- Assumes MIT license for code
- Assumes CC-BY-4.0 license for all other files
- Fixes #4