### PR TITLE
Apply REUSE licensing

### DIFF
--- a/.github/workflows/check-reuse-compliance.yml
+++ b/.github/workflows/check-reuse-compliance.yml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2020 Free Software Foundation Europe e.V.
+# SPDX-License-Identifier: CC0-1.0
+name: REUSE Compliance Check
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v6

--- a/LICENSES/CC-BY-4.0.txt
+++ b/LICENSES/CC-BY-4.0.txt
@@ -1,0 +1,156 @@
+Creative Commons Attribution 4.0 International
+
+ Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+
+Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
+
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+Section 1 – Definitions.
+
+     a.	Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+
+     b.	Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+
+     c.	Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+     d.	Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+     e.	Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+     f.	Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+     g.	Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+     h.	Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+
+     i.	Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+     j.	Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+     k.	You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+     a.	License grant.
+
+          1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+               A. reproduce and Share the Licensed Material, in whole or in part; and
+
+               B. produce, reproduce, and Share Adapted Material.
+
+          2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+          3. Term. The term of this Public License is specified in Section 6(a).
+
+          4. Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+          5. Downstream recipients.
+
+               A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+               B. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+          6.  No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+b. Other rights.
+
+          1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+          2. Patent and trademark rights are not licensed under this Public License.
+
+          3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+     a.	Attribution.
+
+          1. If You Share the Licensed Material (including in modified form), You must:
+
+               A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+                    i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+                    ii. a copyright notice;
+
+                    iii. a notice that refers to this Public License;
+
+                    iv.	a notice that refers to the disclaimer of warranties;
+
+                    v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+               B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+               C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+          2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+          3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+          4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+     a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+
+     b.	if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+
+     c.	You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+     a.	Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
+
+     b.	To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
+
+     c.	The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+     a.	This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+     b.	Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+          1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+          2. upon express reinstatement by the Licensor.
+
+     c.	For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+     d.	For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+     e.	Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+     a.	The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+     b.	Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+     a.	For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+     b.	To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+     c.	No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+     d.	Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,14 @@
+version = 1
+SPDX-PackageName = "Extract-URLs"
+
+[[annotations]]
+path = ["**/*"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2021 Emily Escamilla"
+SPDX-License-Identifier = "CC-BY-4.0"
+
+[[annotations]]
+path = ["**/*.py", "**/*.Rmd"]
+precedence = "override"
+SPDX-FileCopyrightText = "2021 Emily Escamilla"
+SPDX-License-Identifier = "MIT"

--- a/raw_data_outputs/class_pmc_results/PMC-result103.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result103.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result135.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result135.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result146.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result146.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result260.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result260.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result27.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result27.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result288.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result288.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result30.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result30.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result310.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result310.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result33.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result33.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result392.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result392.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result395.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result395.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result406.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result406.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result414.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result414.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result432.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result432.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result437.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result437.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result440.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result440.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result447.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result447.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result468.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result468.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result469.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result469.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result474.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result474.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result483.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result483.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result484.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result484.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result487.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result487.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result494.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result494.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result496.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result496.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result524.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result524.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result525.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result525.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result526.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result526.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result528.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result528.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result539.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result539.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result546.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result546.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result572.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result572.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result578.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result578.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result590.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result590.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result605.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result605.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result606.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result606.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result607.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result607.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result608.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result608.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result609.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result609.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result611.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result611.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result612.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result612.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result613.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result613.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result616.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result616.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result618.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result618.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result619.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result619.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result620.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result620.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result621.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result621.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result623.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result623.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result624.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result624.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result626.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result626.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result627.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result627.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result628.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result628.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result629.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result629.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result630.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result630.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result631.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result631.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result632.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result632.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result633.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result633.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result634.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result634.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result635.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result635.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result636.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result636.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result637.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result637.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result639.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result639.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result642.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result642.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result643.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result643.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result646.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result646.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result647.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result647.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result649.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result649.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result652.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result652.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result653.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result653.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result655.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result655.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result656.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result656.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result658.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result658.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result661.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result661.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result662.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result662.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result664.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result664.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/class_pmc_results/PMC-result665.csv.license
+++ b/raw_data_outputs/class_pmc_results/PMC-result665.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_dataset3/Arxiv-output839.csv.license
+++ b/raw_data_outputs/oads_dataset3/Arxiv-output839.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output/Arxiv-Output174.csv.license
+++ b/raw_data_outputs/oads_output/Arxiv-Output174.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output/Arxiv-Output187.csv.license
+++ b/raw_data_outputs/oads_output/Arxiv-Output187.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output/Arxiv-Output199.csv.license
+++ b/raw_data_outputs/oads_output/Arxiv-Output199.csv.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2021 Emily EscamillaSPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output/Arxiv-Output225.csv.license
+++ b/raw_data_outputs/oads_output/Arxiv-Output225.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output/Arxiv-Output376.csv.license
+++ b/raw_data_outputs/oads_output/Arxiv-Output376.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output2/Arxiv-Output445.csv.license
+++ b/raw_data_outputs/oads_output2/Arxiv-Output445.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output2/Arxiv-Output466.csv.license
+++ b/raw_data_outputs/oads_output2/Arxiv-Output466.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output2/Arxiv-Output492.csv.license
+++ b/raw_data_outputs/oads_output2/Arxiv-Output492.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output2/Arxiv-Output611.csv.license
+++ b/raw_data_outputs/oads_output2/Arxiv-Output611.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output2/Arxiv-Output626.csv.license
+++ b/raw_data_outputs/oads_output2/Arxiv-Output626.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output2/Arxiv-Output679.csv.license
+++ b/raw_data_outputs/oads_output2/Arxiv-Output679.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output2/Arxiv-Output695.csv.license
+++ b/raw_data_outputs/oads_output2/Arxiv-Output695.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output2/Arxiv-Output797.csv.license
+++ b/raw_data_outputs/oads_output2/Arxiv-Output797.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/raw_data_outputs/oads_output2/Arxiv-Output817.csv.license
+++ b/raw_data_outputs/oads_output2/Arxiv-Output817.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 Emily Escamilla
+
+SPDX-License-Identifier: CC-BY-4.0


### PR DESCRIPTION
This is a fix for #4 that creates compliance with the [REUSE Specifications](https://reuse.software/).

- Add `REUSE.toml` to aggregate license information for all files
- Assumes same copyright as master thesis with year of initial commit
- Assumes MIT license for code
- Assumes CC-BY-4.0 license for all other files
- Add a CI pipeline to check compliance
- Fixes #4